### PR TITLE
studio: fix iOS Safari zoom on chat input and tighten Settings on mobile

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -310,7 +310,7 @@ const Composer: FC<{ disabled?: boolean }> = ({ disabled }) => {
         <ToolStatusDisplay />
         <ComposerPrimitive.Input
           placeholder="Send a message..."
-          className="aui-composer-input mb-1 min-h-12 w-full resize-none overflow-y-auto bg-transparent pl-5 pr-4 pt-2 pb-3 text-sm font-[450] outline-none placeholder:text-muted-foreground focus-visible:ring-0"
+          className="aui-composer-input mb-1 min-h-12 w-full resize-none overflow-y-auto bg-transparent pl-5 pr-4 pt-2 pb-3 text-base sm:text-sm font-[450] outline-none placeholder:text-muted-foreground focus-visible:ring-0"
           minRows={1}
           maxRows={6}
           autoFocus={!disabled}
@@ -922,7 +922,7 @@ const EditComposer: FC = () => {
     <MessagePrimitive.Root className="aui-edit-composer-wrapper mx-auto flex w-full max-w-(--thread-content-max-width) flex-col py-3">
       <ComposerPrimitive.Root className="aui-edit-composer-root ml-auto flex w-full max-w-[85%] flex-col rounded-2xl bg-muted">
         <ComposerPrimitive.Input
-          className="aui-edit-composer-input min-h-14 w-full resize-none bg-transparent p-4 text-foreground text-sm font-[450] outline-none"
+          className="aui-edit-composer-input min-h-14 w-full resize-none bg-transparent p-4 text-foreground text-base sm:text-sm font-[450] outline-none"
           autoFocus={true}
         />
         <div className="aui-edit-composer-footer mx-3 mb-3 flex items-center gap-2 self-end">

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -534,7 +534,7 @@ export function SharedComposer({
         onChange={(e) => setText(e.target.value)}
         onKeyDown={onKeyDown}
         placeholder="Send to both models..."
-        className="mb-1 min-h-12 w-full resize-none overflow-y-hidden bg-transparent pl-5 pr-4 pt-2 pb-3 text-sm font-[450] outline-none placeholder:text-muted-foreground focus-visible:ring-0"
+        className="mb-1 min-h-12 w-full resize-none overflow-y-hidden bg-transparent pl-5 pr-4 pt-2 pb-3 text-base sm:text-sm font-[450] outline-none placeholder:text-muted-foreground focus-visible:ring-0"
         rows={1}
       />
       <div className="relative mx-2 mb-2 flex items-center justify-between">

--- a/studio/frontend/src/features/settings/components/settings-row.tsx
+++ b/studio/frontend/src/features/settings/components/settings-row.tsx
@@ -20,7 +20,7 @@ export function SettingsRow({
   return (
     <div
       className={cn(
-        "flex items-center justify-between gap-6 py-3",
+        "flex items-center justify-between gap-6 py-3 max-sm:flex-col max-sm:items-start max-sm:gap-2",
         destructive && "border-t border-border/60 mt-2 pt-4",
         className,
       )}

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -83,7 +83,7 @@ export function SettingsDialog() {
           Manage your Unsloth Studio preferences.
         </DialogDescription>
         <div className="flex h-full min-h-0">
-          <aside className="font-heading flex w-[200px] shrink-0 flex-col border-r border-border bg-muted/20 p-2">
+          <aside className="font-heading flex w-[200px] max-sm:w-[56px] shrink-0 flex-col border-r border-border bg-muted/20 p-2">
             <nav className="flex flex-col gap-0.5">
               {TABS.map((tab) => {
                 const active = activeTab === tab.id;
@@ -93,7 +93,7 @@ export function SettingsDialog() {
                     type="button"
                     onClick={() => setActiveTab(tab.id)}
                     className={cn(
-                      "relative flex h-[30px] items-center gap-2.5 rounded-[8px] px-2.5 text-sm font-medium transition-colors",
+                      "relative flex h-[30px] items-center gap-2.5 rounded-[8px] px-2.5 text-sm font-medium transition-colors max-sm:justify-center max-sm:px-0",
                       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
                       active
                         ? "text-black dark:text-white"
@@ -121,7 +121,7 @@ export function SettingsDialog() {
                       strokeWidth={1.5}
                       className="relative z-10 size-[18px]"
                     />
-                    <span className="relative z-10">{tab.label}</span>
+                    <span className="relative z-10 max-sm:sr-only">{tab.label}</span>
                   </button>
                 );
               })}


### PR DESCRIPTION
iOS Safari force-zooms any focused text input whose font-size is below 16px.
The chat composer and edit composer textareas were styled `text-sm` (14px),
causing an unwanted zoom-in whenever the user tapped to type. Bump them to
`text-base` on mobile and keep `text-sm` from `sm:` upward.

The Settings dialog already went full-screen on mobile but kept the 200px
left rail unconditionally, leaving very little room for the right pane on
phones. Make the rail icon-only below `sm` (56px wide, hidden labels via
`sr-only`) and let SettingsRow stack label-over-control on small screens.

https://claude.ai/code/session_01UyVDjxFLzXJDs5rE8i6BwD