### PR TITLE
Isolate cache directory for source installs via UNSLOTH_STUDIO_HOME

### DIFF
--- a/studio/backend/utils/paths/storage_roots.py
+++ b/studio/backend/utils/paths/storage_roots.py
@@ -193,10 +193,17 @@ def _setup_cache_env() -> None:
     Works on Linux, macOS, and Windows.
     """
     root = cache_root()
-    xdg_cache = Path(
-        os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")
-    ).expanduser()
-    hf_default = xdg_cache / "huggingface"
+    # Local source install (UNSLOTH_STUDIO_HOME set by install-source.sh)
+    # keeps every cache inside the checkout so nothing leaks into ~/.cache.
+    # Standard installs follow the platform default (~/.cache/huggingface or
+    # XDG_CACHE_HOME) so models stay shared with other HF tooling.
+    if os.environ.get("UNSLOTH_STUDIO_HOME"):
+        hf_default = root / "huggingface"
+    else:
+        xdg_cache = Path(
+            os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")
+        ).expanduser()
+        hf_default = xdg_cache / "huggingface"
     defaults: dict[str, str] = {
         "HF_HOME": str(hf_default),
         "HF_HUB_CACHE": str(hf_default / "hub"),


### PR DESCRIPTION
## Summary
Modified cache directory setup to support isolated caching for source installations while maintaining standard platform defaults for regular installs.

## Key Changes
- Added conditional logic to check for `UNSLOTH_STUDIO_HOME` environment variable
- When `UNSLOTH_STUDIO_HOME` is set (source installs via install-source.sh), cache is stored within the checkout directory under `huggingface/`
- When `UNSLOTH_STUDIO_HOME` is not set (standard installs), cache follows platform defaults:
  - Uses `XDG_CACHE_HOME` on Linux if set, otherwise `~/.cache`
  - Falls back to `~/.cache/huggingface` on macOS and Windows
- This ensures source installs don't pollute user's home directory cache while allowing standard installs to share models with other Hugging Face tooling

## Implementation Details
- The change is backward compatible - existing standard installations continue to use platform defaults
- Source installations benefit from isolated, self-contained caching that stays within the project checkout
- Added explanatory comments documenting the two installation scenarios and their cache behavior

https://claude.ai/code/session_01RQw6YKckWaL9j6BJYRT6AJ